### PR TITLE
Updated requirements file to use cuda 10.0 versions of torch/torchvision for DiMP_LTMU. Fixed keyword argument in show_res

### DIFF
--- a/DiMP_LTMU/requirements.txt
+++ b/DiMP_LTMU/requirements.txt
@@ -1,3 +1,4 @@
+-f https://download.pytorch.org/whl/torch_stable.html
 absl-py==0.8.1
 addict==2.2.1
 albumentations==0.4.5
@@ -73,9 +74,9 @@ tensorflow==1.15.0
 tensorflow-estimator==1.15.1
 termcolor==1.1.0
 terminaltables==3.1.0
-torch==1.4.0
+torch==1.4.0+cu100
 torchfile==0.1.0
-torchvision==0.5.0
+torchvision==0.5.0+cu100
 tornado==6.0.3
 tqdm==4.32.0
 urllib3==1.25.9

--- a/DiMP_LTMU/tracker_vot.py
+++ b/DiMP_LTMU/tracker_vot.py
@@ -532,7 +532,7 @@ class Dimp_LTMU_Tracker(object):
         if self.p.visualization:
             show_res(cv2.cvtColor(image, cv2.COLOR_RGB2BGR), np.array(self.last_gt, dtype=np.int32), '2',
                      update=update, can_bboxes=candidate_bboxes,
-                     frame_id=self.i, score=md_score, mask=mask)
+                     frame_id=self.i, tracker_score=md_score, mask=mask)
 
         return vot.Rectangle(float(self.last_gt[1]), float(self.last_gt[0]), float(width),
                 float(height)), confidence_score


### PR DESCRIPTION
I've been working with this repository for my own experiments, fixed a couple issues:
1 ) Default requirements will download CUDA 10.1 version of torch/torchvision, but tensorflow needs 10.0. 
2) In tracker_vot, the keyword argument for show_res is tracker_score, not score